### PR TITLE
Add type hints and improve docstrings in blast/models and blast/utils

### DIFF
--- a/blast/models/degradation_model.py
+++ b/blast/models/degradation_model.py
@@ -346,22 +346,22 @@ class BatteryDegradationModel:
         idx_turning_point: np.ndarray,
         max_time_diff_s=86400,
         max_EFC_diff=1,
-    ):
+    )->list:
         """
         Find breakpoints for simulating battery degradation, where degradation is calculated once
         a certain number of equivalent full cycles has passed, otherwise after a certain time has passed.
         Defaults are to calculate degradation every 1 EFC or every day.
 
         Args:
-            time_seconds (np.ndarray)       Time in seconds
-            EFCs (np.ndarray)               Equivalent full cycles
-            idx_turning_point (np.ndarray)  List of indices in the SOC profile that represent
+            time_seconds (np.ndarray):       Time in seconds
+            EFCs (np.ndarray):             Equivalent full cycles
+            idx_turning_point (np.ndarray):  List of indices in the SOC profile that represent
                                             the end of cycles
-            max_time_diff_s (int)           Maximum time difference in seconds
-            max_EFC_diff (int)              Maximum difference in equivalent full cycles
+            max_time_diff_s (int,optional):           Maximum time difference in seconds
+            max_EFC_diff (int,optional):              Maximum difference in equivalent full cycles
 
         Return:
-            breakpoints (list)
+            breakpoints(list)
         """
 
         breakpoints = []
@@ -387,18 +387,18 @@ class BatteryDegradationModel:
         return breakpoints
 
     def update_battery_state(
-        self, t_secs: np.ndarray, soc: np.ndarray, T_celsius: np.ndarray
-    ):
+        self, t_secs: np.ndarray, soc: np.ndarray, T_celsius: np.ndarray )->None:
         """
         Update the battery states, based both on the degradation state as well as the battery performance
         at the ambient temperature, T_celsius. This function assumes battery load is changing all the time.
 
         Args:
-            t_secs (np.ndarray)     Vector of the time in seconds since beginning of life
-                                    for the soc_timeseries data points
+            t_secs (np.ndarray):     Vector of the time in seconds since beginning of life for the soc_timeseries data points
             soc (np.ndarray):       Vector of the state-of-charge of the battery at each t_sec
-            T_celsius (ndarray)     Temperature of the battery during this time period, in Celsius units.
+            T_celsius (np.ndarray):     Temperature of the battery during this time period, in Celsius units.
 
+        Returns:
+            None
         """
 
         # Check some input types:
@@ -438,8 +438,11 @@ class BatteryDegradationModel:
         Update the battery states, based both on the degradation state as well as the battery performance
         at the ambient temperature, T_celsius. This function assumes battery load is repeating, i.e., stressors and
         degradation rates are unchanging for every timestep, and don't need to be calculated again.
-
         Updates self.states and self.outputs inplace.
+        Args:
+            is_conserve_energy_throughput (bool, optional):
+        Return:
+            None
         """
 
         # Just accumulate the cumulative stressors (total time, charge throughput in units of EFCs)
@@ -477,7 +480,9 @@ class BatteryDegradationModel:
         Updates self.rates inplace.
 
         Args:
-            stressors (dict)    Output from extract_stressors()
+            stressors (dict):    Output from extract_stressors()
+        Returns:
+            None
         """
         pass
 
@@ -489,7 +494,9 @@ class BatteryDegradationModel:
         Updates self.states inplace.
 
         Args:
-            stressors (dict)    Output from extract_stressors()
+            stressors (dict):    Output from extract_stressors()
+        Returns:
+            None
         """
         pass
 
@@ -500,7 +507,7 @@ class BatteryDegradationModel:
         Updates self.outputs inplace.
 
         Args:
-            stressors (dict)    Output from extract_stressors()
+            stressors (dict):    Output from extract_stressors()
         """
         pass
 
@@ -511,12 +518,12 @@ class BatteryDegradationModel:
         temperature, Ua, C-rate, and cycles.
 
         Args:
-            t_secs (np.ndarray)     Array of time in seconds
-            soc (np.ndarray)        Array of SOC
-            T_celsius (np.ndarray)  Array of temperatures in C
+            t_secs (np.ndarray):     Array of time in seconds
+            soc (np.ndarray):        Array of SOC
+            T_celsius (np.ndarray):  Array of temperatures in C
 
         Return:
-            stressors (dict)        Dictionary of stressor values.
+            stressors (dict):        Dictionary of stressor values.
 
         """
         # Extract stressors

--- a/blast/models/lfp_gr_250AhPrismatic_2019.py
+++ b/blast/models/lfp_gr_250AhPrismatic_2019.py
@@ -108,10 +108,16 @@ class Lfp_Gr_250AhPrismatic(BatteryDegradationModel):
             'pcyc': 0.828,
         }
     
-    def update_rates(self, stressors):
-        # Calculate and update battery degradation rates based on stressor values
-        # Inputs:
-        #   stressors (dict): output from extract_stressors
+    def update_rates(self, stressors:dict)->None:
+        """
+        Calculate and update battery degradation rates based on stressor values.
+
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
 
         # Unpack stressors
         t_secs = stressors["t_secs"]
@@ -142,11 +148,16 @@ class Lfp_Gr_250AhPrismatic(BatteryDegradationModel):
         for k, v in zip(self.rates.keys(), rates):
             self.rates[k] = np.append(self.rates[k], v)
     
-    def update_states(self, stressors):
-        # Update the battery states, based both on the degradation state as well as the battery performance
-        # at the ambient temperature, T_celsius
-        # Inputs:
-            #   stressors (dict): output from extract_stressors
+    def update_states(self, stressors:dict)->None:
+        """
+        Update the battery degradation states based on the latest stressor values.
+
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
             
         # Unpack stressors
         delta_t_days = stressors["delta_t_days"]
@@ -172,8 +183,16 @@ class Lfp_Gr_250AhPrismatic(BatteryDegradationModel):
             x = self.states[k][-1] + v
             self.states[k] = np.append(self.states[k], x)
     
-    def update_outputs(self, stressors):
-        # Calculate outputs, based on current battery state
+    def update_outputs(self, stressors:dict)->None:
+        """
+        Calculate outputs, based on current battery state
+
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
         states = self.states
 
         # Capacity

--- a/blast/models/lfp_gr_SonyMurata3Ah_2018.py
+++ b/blast/models/lfp_gr_SonyMurata3Ah_2018.py
@@ -159,11 +159,15 @@ class Lfp_Gr_SonyMurata3Ah_Battery(BatteryDegradationModel):
             'D_r_cyc': 0.91882
         }
     
-    def update_rates(self, stressors: dict):
-        # Calculate and update battery degradation rates based on stressor values
-        # Inputs:
-        #   stressors (dict): output from extract_stressors
+    def update_rates(self, stressors: dict)->None:
+        """
+        Calculate and update battery degradation rates based on stressor values.
 
+        Args:
+            stressors (dict): Output from extract_stressors
+        Returns:
+            None
+        """
         def _sigmoid(x, alpha, beta, gamma):
             return 2*alpha*(1/2 - 1/(1 + np.exp((beta*x)**gamma)))
 
@@ -230,12 +234,16 @@ class Lfp_Gr_SonyMurata3Ah_Battery(BatteryDegradationModel):
         for k, v in zip(self.rates.keys(), rates):
             self.rates[k] = np.append(self.rates[k], v)
     
-    def update_states(self, stressors: dict):
-        # Update the battery states, based both on the degradation state as well as the battery performance
-        # at the ambient temperature, T_celsius
-        # Inputs:
-            #   stressors (dict): output from extract_stressors
-            
+    def update_states(self, stressors: dict)->None:
+        """
+        Update the battery states, based both on the degradation state as well as the battery performance 
+        at the ambient temperature, T_celsius
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
         # Unpack stressors
         delta_t_days = stressors["delta_t_days"]
         delta_efc = stressors["delta_efc"]
@@ -269,8 +277,14 @@ class Lfp_Gr_SonyMurata3Ah_Battery(BatteryDegradationModel):
             x = self.states[k][-1] + v
             self.states[k] = np.append(self.states[k], x)
     
-    def update_outputs(self, stressors):
-        # Calculate outputs, based on current battery state
+    def update_outputs(self, stressors:dict)->None:
+        """
+        Calculate outputs, based on current battery state
+        Args:
+            stressors (dict): Output from extract_stressors
+        Returns:
+            None
+        """
         states = self.states
 
         # Capacity

--- a/blast/models/lmo_gr_NissanLeaf66Ah_2ndLife_2020.py
+++ b/blast/models/lmo_gr_NissanLeaf66Ah_2ndLife_2020.py
@@ -99,8 +99,16 @@ class Lmo_Gr_NissanLeaf66Ah_2ndLife_Battery(BatteryDegradationModel):
         }
         
     # Battery model    
-    def update_rates(self, stressors):
-        # Calculate and update battery degradation rates based on stressor values
+    def update_rates(self, stressors:dict)->None:
+        """
+        Calculate and update battery degradation rates based on stressor values
+        
+        Args:
+            stressors (dict): Output from extract_stressors
+            
+        Returns:
+            None
+        """
         # Inputs:
         #   stressors (dict): output from extract_stressors
 
@@ -127,11 +135,16 @@ class Lmo_Gr_NissanLeaf66Ah_2ndLife_Battery(BatteryDegradationModel):
         for k, v in zip(self.rates.keys(), rates):
             self.rates[k] = np.append(self.rates[k], v)
 
-    def update_states(self, stressors):
-        # Update the battery states, based both on the degradation state as well as the battery performance
-        # at the ambient temperature, T_celsius
-        # Inputs:
-            #   stressors (dict): output from extract_stressors
+    def update_states(self, stressors:dict)->None:
+        """
+        Update the battery states, based both on the degradation state as well as the battery performance 
+        at the ambient temperature, T_celsius
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
             
         # Unpack stressors
         delta_t_days = stressors["delta_t_days"]
@@ -157,8 +170,15 @@ class Lmo_Gr_NissanLeaf66Ah_2ndLife_Battery(BatteryDegradationModel):
             x = self.states[k][-1] + v
             self.states[k] = np.append(self.states[k], x)
     
-    def update_outputs(self, stressors):
-        # Calculate outputs, based on current battery state
+    def update_outputs(self, stressors:dict)->None:
+        """
+        Calculate outputs, based on current battery state
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
         states = self.states
 
         # Capacity

--- a/blast/models/nca_gr_Panasonic3Ah_2018.py
+++ b/blast/models/nca_gr_Panasonic3Ah_2018.py
@@ -108,10 +108,16 @@ class Nca_Gr_Panasonic3Ah_Battery(BatteryDegradationModel):
         }
         
     # Battery model
-    def update_rates(self, stressors):
-        # Calculate and update battery degradation rates based on stressor values
-        # Inputs:
-        #   stressors (dict): output from extract_stressors
+    def update_rates(self, stressors:dict)->None:
+        """
+        Calculate and update battery degradation rates based on stressor values
+        
+        Args:
+            stressors (dict): Output from extract_stressors
+            
+        Returns:
+            None
+        """
 
         # Unpack stressors
         t_secs = stressors["t_secs"]
@@ -144,11 +150,16 @@ class Nca_Gr_Panasonic3Ah_Battery(BatteryDegradationModel):
             self.rates[k] = np.append(self.rates[k], v)
 
     
-    def update_states(self, stressors):
-        # Update the battery states, based both on the degradation state as well as the battery performance
-        # at the ambient temperature, T_celsius
-        # Inputs:
-            #   stressors (dict): output from extract_stressors
+    def update_states(self, stressors:dict)->None:
+        """
+        Update the battery states, based both on the degradation state as well as the battery performance 
+        at the ambient temperature, T_celsius
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
             
         # Unpack stressors
         delta_t_days = stressors["delta_t_days"]
@@ -174,8 +185,15 @@ class Nca_Gr_Panasonic3Ah_Battery(BatteryDegradationModel):
             x = self.states[k][-1] + v
             self.states[k] = np.append(self.states[k], x)
     
-    def update_outputs(self, stressors):
-        # Calculate outputs, based on current battery state
+    def update_outputs(self, stressors:dict)->None:
+        """
+        Calculate outputs, based on current battery state
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
         states = self.states
 
         # Capacity

--- a/blast/models/nca_grsi_SonyMurata2p5Ah_2023.py
+++ b/blast/models/nca_grsi_SonyMurata2p5Ah_2023.py
@@ -131,14 +131,25 @@ class NCA_GrSi_SonyMurata2p5Ah_Battery(BatteryDegradationModel):
         }
 
     # Override super class update_battery_state because this model uses a few unusual stressors
-    def update_battery_state(self, t_secs, soc, T_celsius):
-        # Update the battery states, based both on the degradation state as well as the battery performance
-        # at the ambient temperature, T_celsius. This function assumes battery load is changing all the time.
-        # Inputs:
-            #   t_secs (ndarry): vector of the time in seconds since beginning of life for the soc_timeseries data points
-            #   soc (ndarry): vector of the state-of-charge of the battery at each t_sec
-            #   T_celsius (ndarray): the temperature of the battery during this time period, in Celsius units.
-            
+        
+    def update_battery_state(
+        self,
+        t_secs: np.ndarray,
+        soc: np.ndarray,
+        T_celsius: np.ndarray
+        ) -> None:
+        """
+        Update the battery states, based both on the degradation state as well as the battery performance
+        at the ambient temperature, T_celsius. This function assumes battery load is changing all the time.
+
+        Args:
+            t_secs (np.ndarray): Time vector in seconds since beginning of life.
+            soc (np.ndarray): State-of-charge values corresponding to each time step.
+            T_celsius (np.ndarray): Battery temperature during the time period.
+
+        Returns:
+            None
+        """
         # Check some input types:
         if not isinstance(t_secs, np.ndarray):
             raise TypeError('Input "t_secs" must be a numpy.ndarray')
@@ -174,10 +185,16 @@ class NCA_GrSi_SonyMurata2p5Ah_Battery(BatteryDegradationModel):
         self.update_outputs(stressors)
         # print(f"q_t: {self.outputs['q_t'][-1]}, q_EFC: {self.outputs['q_EFC'][-1]}, q: {self.outputs['q'][-1]}")
 
-    def update_rates(self, stressors):
-        # Calculate and update battery degradation rates based on stressor values
-        # Inputs:
-        #   stressors (dict): output from extract_stressors
+    def update_rates(self, stressors:dict)->None:
+        """
+        Calculate and update battery degradation rates based on stressor values
+        
+        Args:
+            stressors (dict): Output from extract_stressors
+            
+        Returns:
+            None
+        """
 
         # Unpack stressors
         t_secs = stressors["t_secs"]
@@ -237,11 +254,16 @@ class NCA_GrSi_SonyMurata2p5Ah_Battery(BatteryDegradationModel):
         for k, v in zip(self.rates.keys(), rates):
             self.rates[k] = np.append(self.rates[k], v)
     
-    def update_states(self, stressors):
-        # Update the battery states, based both on the degradation state as well as the battery performance
-        # at the ambient temperature, T_celsius
-        # Inputs:
-            #   stressors (dict): output from extract_stressors
+    def update_states(self, stressors:dict)->None:
+        """
+        Update the battery states, based both on the degradation state as well as the battery performance 
+        at the ambient temperature, T_celsius
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
             
         # Unpack stressors
         delta_t_days = stressors["delta_t_days"]
@@ -268,8 +290,15 @@ class NCA_GrSi_SonyMurata2p5Ah_Battery(BatteryDegradationModel):
             x = self.states[k][-1] + v
             self.states[k] = np.append(self.states[k], x)
     
-    def update_outputs(self, stressors):
-        # Calculate outputs, based on current battery state
+    def update_outputs(self, stressors:dict)->None:
+        """
+        Calculate outputs, based on current battery state
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
         states = self.states
 
         # Capacity
@@ -283,8 +312,22 @@ class NCA_GrSi_SonyMurata2p5Ah_Battery(BatteryDegradationModel):
         for k, v in zip(list(self.outputs.keys()), out):
             self.outputs[k] = np.append(self.outputs[k], v)
     
-    def _extract_stressors(self, t_secs, soc, T_celsius):
-        # extract the usual stressors
+    def _extract_stressors(
+        self,
+        t_secs: np.ndarray,
+        soc: np.ndarray,
+        T_celsius: np.ndarray
+        ) -> dict:
+        """
+        extract the usual stressors
+        Args:
+            t_secs (np.ndarray): Time vector in seconds since beginning of life.
+            soc (np.ndarray): State-of-charge values corresponding to each time step.
+            T_celsius (np.ndarray): Battery temperature during the time period.
+
+        Returns:
+            dict: Stressor values extracted from the input.
+        """
         stressors = BatteryDegradationModel._extract_stressors(self, t_secs, soc, T_celsius)
         # model specific stressors: soc_low, soc_high, Cchg, Cdis
         soc_low = np.min(soc)

--- a/blast/models/nmc111_gr_Kokam75Ah_2017.py
+++ b/blast/models/nmc111_gr_Kokam75Ah_2017.py
@@ -130,10 +130,16 @@ class Nmc111_Gr_Kokam75Ah_Battery(BatteryDegradationModel):
         }
     
     # Battery model
-    def update_rates(self, stressors):
-        # Calculate and update battery degradation rates based on stressor values
-        # Inputs:
-        #   stressors (dict): output from extract_stressors
+    def update_rates(self, stressors:dict)->None:
+        """
+        Calculate and update battery degradation rates based on stressor values
+        
+        Args:
+            stressors (dict): Output from extract_stressors
+            
+        Returns:
+            None
+        """
 
         # Unpack stressors
         t_secs = stressors["t_secs"]
@@ -164,11 +170,16 @@ class Nmc111_Gr_Kokam75Ah_Battery(BatteryDegradationModel):
         for k, v in zip(self.rates.keys(), rates):
             self.rates[k] = np.append(self.rates[k], v)
 
-    def update_states(self, stressors):
-        # Update the battery states, based both on the degradation state as well as the battery performance
-        # at the ambient temperature, T_celsius
-        # Inputs:
-            #   stressors (dict): output from extract_stressors
+    def update_states(self, stressors:dict)->None:
+        """
+        Update the battery states, based both on the degradation state as well as the battery performance 
+        at the ambient temperature, T_celsius
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
             
         # Unpack stressors
         delta_t_days = stressors["delta_t_days"]
@@ -199,8 +210,15 @@ class Nmc111_Gr_Kokam75Ah_Battery(BatteryDegradationModel):
             x = self.states[k][-1] + v
             self.states[k] = np.append(self.states[k], x)
 
-    def update_outputs(self, stressors):
-        # Calculate outputs, based on current battery state
+    def update_outputs(self, stressors:dict)->None:
+        """
+        Calculate outputs, based on current battery state
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
         states = self.states
         p = self._params_life
 

--- a/blast/models/nmc111_gr_Sanyo2Ah_2014.py
+++ b/blast/models/nmc111_gr_Sanyo2Ah_2014.py
@@ -135,10 +135,16 @@ class Nmc111_Gr_Sanyo2Ah_Battery(BatteryDegradationModel):
         }
         
     # Battery model
-    def update_rates(self, stressors):
-        # Calculate and update battery degradation rates based on stressor values
-        # Inputs:
-        #   stressors (dict): output from extract_stressors
+    def update_rates(self, stressors:dict)->None:
+        """
+        Calculate and update battery degradation rates based on stressor values
+        
+        Args:
+            stressors (dict): Output from extract_stressors
+            
+        Returns:
+            None
+        """
 
         # Unpack stressors
         t_secs = stressors["t_secs"]
@@ -177,11 +183,16 @@ class Nmc111_Gr_Sanyo2Ah_Battery(BatteryDegradationModel):
         for k, v in zip(self.rates.keys(), rates):
             self.rates[k] = np.append(self.rates[k], v)
     
-    def update_states(self, stressors):
-        # Update the battery states, based both on the degradation state as well as the battery performance
-        # at the ambient temperature, T_celsius
-        # Inputs:
-            #   stressors (dict): output from extract_stressors
+    def update_states(self, stressors:dict)->None:
+        """
+        Update the battery states, based both on the degradation state as well as the battery performance 
+        at the ambient temperature, T_celsius
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
             
         # Unpack stressors
         delta_t_days = stressors["delta_t_days"]
@@ -211,8 +222,15 @@ class Nmc111_Gr_Sanyo2Ah_Battery(BatteryDegradationModel):
             x = self.states[k][-1] + v
             self.states[k] = np.append(self.states[k], x)
     
-    def update_outputs(self, stressors):
-        # Calculate outputs, based on current battery state
+    def update_outputs(self, stressors:dict)->None:
+        """
+        Calculate outputs, based on current battery state
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
         states = self.states
         p = self._params_life
 

--- a/blast/models/nmc622_gr_DENSO50Ah_2021.py
+++ b/blast/models/nmc622_gr_DENSO50Ah_2021.py
@@ -123,10 +123,16 @@ class Nmc622_Gr_DENSO50Ah_Battery(BatteryDegradationModel):
         return np.exp(-(Ea/8.3144)*((1/TdegK)-(1/298.15)))
 
     # Battery model
-    def update_rates(self, stressors):
-        # Calculate and update battery degradation rates based on stressor values
-        # Inputs:
-        #   stressors (dict): output from extract_stressors
+    def update_rates(self, stressors:dict)->None:
+        """
+        Calculate and update battery degradation rates based on stressor values
+        
+        Args:
+            stressors (dict): Output from extract_stressors
+            
+        Returns:
+            None
+        """
 
         # Unpack stressors
         t_secs = stressors["t_secs"]
@@ -165,11 +171,16 @@ class Nmc622_Gr_DENSO50Ah_Battery(BatteryDegradationModel):
         for k, v in zip(self.rates.keys(), rates):
             self.rates[k] = np.append(self.rates[k], v)
     
-    def update_states(self, stressors):
-        # Update the battery states, based both on the degradation state as well as the battery performance
-        # at the ambient temperature, T_celsius
-        # Inputs:
-            #   stressors (dict): output from extract_stressors
+    def update_states(self, stressors:dict)->None:
+        """
+        Update the battery states, based both on the degradation state as well as the battery performance 
+        at the ambient temperature, T_celsius
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
             
         # Unpack stressors
         delta_t_days = stressors["delta_t_days"]
@@ -202,8 +213,15 @@ class Nmc622_Gr_DENSO50Ah_Battery(BatteryDegradationModel):
             x = self.states[k][-1] + v
             self.states[k] = np.append(self.states[k], x)
     
-    def update_outputs(self, stressors):
-        # Calculate outputs, based on current battery state
+    def update_outputs(self, stressors:dict)->None:
+        """
+        Calculate outputs, based on current battery state
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
         states = self.states
 
         # Capacity
@@ -218,8 +236,22 @@ class Nmc622_Gr_DENSO50Ah_Battery(BatteryDegradationModel):
         for k, v in zip(list(self.outputs.keys()), out):
             self.outputs[k] = np.append(self.outputs[k], v)
 
-    def _extract_stressors(self, t_secs, soc, T_celsius):
-        # extract the usual stressors
+    def _extract_stressors(
+        self,
+        t_secs: np.ndarray,
+        soc: np.ndarray,
+        T_celsius: np.ndarray
+        ) -> dict:
+        """
+        extract the usual stressors
+        Args:
+            t_secs (np.ndarray): Time vector in seconds since beginning of life.
+            soc (np.ndarray): State-of-charge values corresponding to each time step.
+            T_celsius (np.ndarray): Battery temperature during the time period.
+
+        Returns:
+            dict: Stressor values extracted from the input.
+        """
         stressors = BatteryDegradationModel._extract_stressors(self, t_secs, soc, T_celsius)
         # model specific stressors: Cchg
         t_days = t_secs / (24*60*60)

--- a/blast/models/nmc811_grSi_LGM50_5Ah_2021.py
+++ b/blast/models/nmc811_grSi_LGM50_5Ah_2021.py
@@ -104,10 +104,16 @@ class Nmc811_GrSi_LGM50_5Ah_Battery(BatteryDegradationModel):
         }
 
     # Battery model
-    def update_rates(self, stressors):
-        # Calculate and update battery degradation rates based on stressor values
-        # Inputs:
-        #   stressors (dict): output from extract_stressors
+    def update_rates(self, stressors:dict)->None:
+        """
+        Calculate and update battery degradation rates based on stressor values
+        
+        Args:
+            stressors (dict): Output from extract_stressors
+            
+        Returns:
+            None
+        """
 
         # Unpack stressors
         t_secs = stressors["t_secs"]
@@ -146,11 +152,16 @@ class Nmc811_GrSi_LGM50_5Ah_Battery(BatteryDegradationModel):
         for k, v in zip(self.rates.keys(), rates):
             self.rates[k] = np.append(self.rates[k], v)
     
-    def update_states(self, stressors):
-        # Update the battery states, based both on the degradation state as well as the battery performance
-        # at the ambient temperature, T_celsius
-        # Inputs:
-            #   stressors (dict): output from extract_stressors
+    def update_states(self, stressors:dict)->None:
+        """
+        Update the battery states, based both on the degradation state as well as the battery performance 
+        at the ambient temperature, T_celsius
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
             
         # Unpack stressors
         delta_t_days = stressors["delta_t_days"]
@@ -176,8 +187,15 @@ class Nmc811_GrSi_LGM50_5Ah_Battery(BatteryDegradationModel):
             x = self.states[k][-1] + v
             self.states[k] = np.append(self.states[k], x)
     
-    def update_outputs(self, stressors):
-        # Calculate outputs, based on current battery state
+    def update_outputs(self, stressors:dict)->None:
+        """
+        Calculate outputs, based on current battery state
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
         states = self.states
 
         # Capacity
@@ -191,8 +209,22 @@ class Nmc811_GrSi_LGM50_5Ah_Battery(BatteryDegradationModel):
         for k, v in zip(list(self.outputs.keys()), out):
             self.outputs[k] = np.append(self.outputs[k], v)
     
-    def _extract_stressors(self, t_secs, soc, T_celsius):
-        # extract the usual stressors
+    def _extract_stressors(
+        self,
+        t_secs: np.ndarray,
+        soc: np.ndarray,
+        T_celsius: np.ndarray
+        ) -> dict:
+        """
+        extract the usual stressors
+        Args:
+            t_secs (np.ndarray): Time vector in seconds since beginning of life.
+            soc (np.ndarray): State-of-charge values corresponding to each time step.
+            T_celsius (np.ndarray): Battery temperature during the time period.
+
+        Returns:
+            dict: Stressor values extracted from the input.
+        """
         stressors = BatteryDegradationModel._extract_stressors(self, t_secs, soc, T_celsius)
         # model specific stressors: Cdis
         t_days = t_secs / (24*60*60)

--- a/blast/models/nmc811_grSi_LGMJ1_4Ah_2020.py
+++ b/blast/models/nmc811_grSi_LGMJ1_4Ah_2020.py
@@ -32,7 +32,10 @@ class Nmc811_GrSi_LGMJ1_4Ah_Battery(BatteryDegradationModel):
             NMC811 is known to degrade quickly at voltages above 4.1 V.
     """
 
-    def __init__(self, degradation_scalar: float = 1, label: str = "NMC811-GrSi LG MJ1"):
+    def __init__(self, degradation_scalar: float = 1, label: str = "NMC811-GrSi LG MJ1")->None:
+        """
+        
+        """
         # States: Internal states of the battery model
         self.states = {
             'qLoss_t': np.array([0]),
@@ -102,10 +105,16 @@ class Nmc811_GrSi_LGMJ1_4Ah_Battery(BatteryDegradationModel):
         }
 
     # Battery model
-    def update_rates(self, stressors):
-        # Calculate and update battery degradation rates based on stressor values
-        # Inputs:
-        #   stressors (dict): output from extract_stressors
+    def update_rates(self, stressors:dict)->None:
+        """
+        Calculate and update battery degradation rates based on stressor values
+        
+        Args:
+            stressors (dict): Output from extract_stressors
+            
+        Returns:
+            None
+        """
 
         # Unpack stressors
         t_secs = stressors["t_secs"]
@@ -135,11 +144,16 @@ class Nmc811_GrSi_LGMJ1_4Ah_Battery(BatteryDegradationModel):
         for k, v in zip(self.rates.keys(), rates):
             self.rates[k] = np.append(self.rates[k], v)
     
-    def update_states(self, stressors):
-        # Update the battery states, based both on the degradation state as well as the battery performance
-        # at the ambient temperature, T_celsius
-        # Inputs:
-            #   stressors (dict): output from extract_stressors
+    def update_states(self, stressors:dict)->None:
+        """
+        Update the battery states, based both on the degradation state as well as the battery performance 
+        at the ambient temperature, T_celsius
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
             
         # Unpack stressors
         delta_t_days = stressors["delta_t_days"]
@@ -165,8 +179,15 @@ class Nmc811_GrSi_LGMJ1_4Ah_Battery(BatteryDegradationModel):
             x = self.states[k][-1] + v
             self.states[k] = np.append(self.states[k], x)
     
-    def update_outputs(self, stressors):
-        # Calculate outputs, based on current battery state
+    def update_outputs(self, stressors:dict)->None:
+        """
+        Calculate outputs, based on current battery state
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
         states = self.states
 
         # Capacity

--- a/blast/models/nmc811_grSi_LGMJ1_4Ah_2020.py
+++ b/blast/models/nmc811_grSi_LGMJ1_4Ah_2020.py
@@ -33,9 +33,7 @@ class Nmc811_GrSi_LGMJ1_4Ah_Battery(BatteryDegradationModel):
     """
 
     def __init__(self, degradation_scalar: float = 1, label: str = "NMC811-GrSi LG MJ1")->None:
-        """
         
-        """
         # States: Internal states of the battery model
         self.states = {
             'qLoss_t': np.array([0]),

--- a/blast/models/nmc_gr_50Ah_B1_2020.py
+++ b/blast/models/nmc_gr_50Ah_B1_2020.py
@@ -101,10 +101,16 @@ class NMC_Gr_50Ah_B1(BatteryDegradationModel):
             'pcyc': 0.467,
         }
     
-    def update_rates(self, stressors):
-        # Calculate and update battery degradation rates based on stressor values
-        # Inputs:
-        #   stressors (dict): output from extract_stressors
+    def update_rates(self, stressors:dict)->None:
+        """
+        Calculate and update battery degradation rates based on stressor values
+        
+        Args:
+            stressors (dict): Output from extract_stressors
+            
+        Returns:
+            None
+        """
 
         # Unpack stressors
         t_secs = stressors["t_secs"]
@@ -139,11 +145,16 @@ class NMC_Gr_50Ah_B1(BatteryDegradationModel):
         for k, v in zip(self.rates.keys(), rates):
             self.rates[k] = np.append(self.rates[k], v)
     
-    def update_states(self, stressors):
-        # Update the battery states, based both on the degradation state as well as the battery performance
-        # at the ambient temperature, T_celsius
-        # Inputs:
-            #   stressors (dict): output from extract_stressors
+    def update_states(self, stressors:dict)->None:
+        """
+        Update the battery states, based both on the degradation state as well as the battery performance 
+        at the ambient temperature, T_celsius
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
             
         # Unpack stressors
         delta_t_days = stressors["delta_t_days"]
@@ -169,8 +180,15 @@ class NMC_Gr_50Ah_B1(BatteryDegradationModel):
             x = self.states[k][-1] + v
             self.states[k] = np.append(self.states[k], x)
     
-    def update_outputs(self, stressors):
-        # Calculate outputs, based on current battery state
+    def update_outputs(self, stressors:dict)->None:
+        """
+        Calculate outputs, based on current battery state
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
         states = self.states
 
         # Capacity

--- a/blast/models/nmc_gr_50Ah_B2_2020.py
+++ b/blast/models/nmc_gr_50Ah_B2_2020.py
@@ -103,10 +103,16 @@ class NMC_Gr_50Ah_B2(BatteryDegradationModel):
             'pcyc': 0.907,
         }
     
-    def update_rates(self, stressors):
-        # Calculate and update battery degradation rates based on stressor values
-        # Inputs:
-        #   stressors (dict): output from extract_stressors
+    def update_rates(self, stressors:dict)->None:
+        """
+        Calculate and update battery degradation rates based on stressor values
+        
+        Args:
+            stressors (dict): Output from extract_stressors
+            
+        Returns:
+            None
+        """
 
         # Unpack stressors
         t_secs = stressors["t_secs"]
@@ -140,11 +146,16 @@ class NMC_Gr_50Ah_B2(BatteryDegradationModel):
         for k, v in zip(self.rates.keys(), rates):
             self.rates[k] = np.append(self.rates[k], v)
     
-    def update_states(self, stressors):
-        # Update the battery states, based both on the degradation state as well as the battery performance
-        # at the ambient temperature, T_celsius
-        # Inputs:
-            #   stressors (dict): output from extract_stressors
+    def update_states(self, stressors:dict)->None:
+        """
+        Update the battery states, based both on the degradation state as well as the battery performance 
+        at the ambient temperature, T_celsius
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
             
         # Unpack stressors
         delta_t_days = stressors["delta_t_days"]
@@ -170,8 +181,15 @@ class NMC_Gr_50Ah_B2(BatteryDegradationModel):
             x = self.states[k][-1] + v
             self.states[k] = np.append(self.states[k], x)
     
-    def update_outputs(self, stressors):
-        # Calculate outputs, based on current battery state
+    def update_outputs(self, stressors:dict)->None:
+        """
+        Calculate outputs, based on current battery state
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
         states = self.states
 
         # Capacity

--- a/blast/models/nmc_gr_75Ah_A_2019.py
+++ b/blast/models/nmc_gr_75Ah_A_2019.py
@@ -101,10 +101,16 @@ class NMC_Gr_75Ah_A(BatteryDegradationModel):
             'pcyc': 1.11,
         }
     
-    def update_rates(self, stressors):
-        # Calculate and update battery degradation rates based on stressor values
-        # Inputs:
-        #   stressors (dict): output from extract_stressors
+    def update_rates(self, stressors:dict)->None:
+        """
+        Calculate and update battery degradation rates based on stressor values
+        
+        Args:
+            stressors (dict): Output from extract_stressors
+            
+        Returns:
+            None
+        """
 
         # Unpack stressors
         t_secs = stressors["t_secs"]
@@ -139,11 +145,16 @@ class NMC_Gr_75Ah_A(BatteryDegradationModel):
         for k, v in zip(self.rates.keys(), rates):
             self.rates[k] = np.append(self.rates[k], v)
     
-    def update_states(self, stressors):
-        # Update the battery states, based both on the degradation state as well as the battery performance
-        # at the ambient temperature, T_celsius
-        # Inputs:
-            #   stressors (dict): output from extract_stressors
+    def update_states(self, stressors:dict)->None:
+        """
+        Update the battery states, based both on the degradation state as well as the battery performance 
+        at the ambient temperature, T_celsius
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
             
         # Unpack stressors
         delta_t_days = stressors["delta_t_days"]
@@ -169,8 +180,15 @@ class NMC_Gr_75Ah_A(BatteryDegradationModel):
             x = self.states[k][-1] + v
             self.states[k] = np.append(self.states[k], x)
     
-    def update_outputs(self, stressors):
-        # Calculate outputs, based on current battery state
+    def update_outputs(self, stressors:dict)->None:
+        """
+        Calculate outputs, based on current battery state
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
         states = self.states
 
         # Capacity

--- a/blast/models/nmc_lto_10Ah_2020.py
+++ b/blast/models/nmc_lto_10Ah_2020.py
@@ -105,10 +105,16 @@ class Nmc_Lto_10Ah_Battery(BatteryDegradationModel):
         }
         
     # Battery model
-    def update_rates(self, stressors):
-        # Calculate and update battery degradation rates based on stressor values
-        # Inputs:
-        #   stressors (dict): output from extract_stressors
+    def update_rates(self, stressors:dict)->None:
+        """
+        Calculate and update battery degradation rates based on stressor values
+        
+        Args:
+            stressors (dict): Output from extract_stressors
+            
+        Returns:
+            None
+        """
 
         # Unpack stressors
         t_secs = stressors["t_secs"]
@@ -141,11 +147,16 @@ class Nmc_Lto_10Ah_Battery(BatteryDegradationModel):
         for k, v in zip(self.rates.keys(), rates):
             self.rates[k] = np.append(self.rates[k], v)
 
-    def update_states(self, stressors):
-        # Update the battery states, based both on the degradation state as well as the battery performance
-        # at the ambient temperature, T_celsius
-        # Inputs:
-            #   stressors (dict): output from extract_stressors
+    def update_states(self, stressors:dict)->None:
+        """
+        Update the battery states, based both on the degradation state as well as the battery performance 
+        at the ambient temperature, T_celsius
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
             
         # Unpack stressors
         delta_t_days = stressors["delta_t_days"]
@@ -172,8 +183,15 @@ class Nmc_Lto_10Ah_Battery(BatteryDegradationModel):
             x = self.states[k][-1] + v
             self.states[k] = np.append(self.states[k], x)
     
-    def update_outputs(self, stressors):
-        # Calculate outputs, based on current battery state
+    def update_outputs(self, stressors:dict)->None:
+        """
+        Calculate outputs, based on current battery state
+        Args:
+            stressors (dict): Output from extract_stressors
+
+        Returns:
+            None
+        """
         states = self.states
 
         # Capacity

--- a/blast/utils/functions.py
+++ b/blast/utils/functions.py
@@ -290,7 +290,7 @@ def scale_vehicle_profile_to_annual_efcs(profile:pd.DataFrame, desired_efcs_per_
             'SOC': profile.loc[idx_reversals[i] + new_row_count, 'SOC'],
             'dSOC': 0
         })
-        after_rest = profile.iloc[idx_reversals[i] + new_row_count:].copy()
+        after_rest = profile.iloc[idx_reversals[i] + new_row_count:]
         new_time = profile.loc[idx_reversals[i] + new_row_count:, 'Time_s'] + rest_time_per_interval
         # cast new_time to same dtype as 'Time_s' column
         new_time = new_time.astype(profile['Time_s'].dtype)

--- a/blast/utils/functions.py
+++ b/blast/utils/functions.py
@@ -13,10 +13,12 @@ def simulate_all_models(*args, **kwargs)->list:
     """
     Simulates all battery models.
 
-    # Arguments
-    
+    Args:
+        *args:args->tuple
+        **kwargs: kwargs->dict
 
-    # Returns
+    Returns:
+        list: cells
     
     """
     models = available_models()

--- a/blast/utils/functions.py
+++ b/blast/utils/functions.py
@@ -9,7 +9,16 @@ import importlib
 from blast.models._available_models import available_models
 from blast.utils.rainflow import reversals
 
-def simulate_all_models(*args, **kwargs):
+def simulate_all_models(*args, **kwargs)->list:
+    """
+    Simulates all battery models.
+
+    # Arguments
+    
+
+    # Returns
+    
+    """
     models = available_models()
     cells = []
     for model in models:
@@ -26,13 +35,13 @@ def get_nsrdb_temperature_data(location: str = "Honolulu, Hawaii") -> pd.DataFra
     provided location, and format for battery life simulation.
 
     Args:
-        location (str):      Descriptive location string.
+    - location (str):      Descriptive location string.
 
     Returns:
-        pd.DataFrame:  Temperature time series at the specified location.
+    - pd.DataFrame:  Temperature time series at the specified location.
     """
 
-    def nearest_site(tree, lat_coord, lon_coord):
+    def nearest_site(tree: cKDTree, lat_coord: float, lon_coord: float)->int:
         lat_lon = np.array([lat_coord, lon_coord])
         dist, pos = tree.query(lat_lon)
         return pos
@@ -80,17 +89,17 @@ def get_nsrdb_temperature_data(location: str = "Honolulu, Hawaii") -> pd.DataFra
 
 def make_inputs_periodic(
     input_timeseries: dict, interp_time_window_hours: float
-) -> pd.DataFrame:
+) -> dict:
     """
     Linearly interpolate the last 'interp_time_window_hours' of the input to ensure periodicity.
 
     Args:
-        input_timeseries (dict):     Dictionary with keys ['Temperature_C', 'SOC', 'Time_s']
+        -input_timeseries (dict):     Dictionary with keys ['Temperature_C', 'SOC', 'Time_s']
                                     and timeseries values.
-        interp_time_window_hours (float):    Number of hours to interpolate, from end of timeseries
+        -interp_time_window_hours (float):    Number of hours to interpolate, from end of timeseries
 
     Returns:
-        dict:    Dictionary with keys ['Temperature_C', 'SOC', 'Time_s'] after interpolation.
+        -dict:    Dictionary with keys ['Temperature_C', 'SOC', 'Time_s'] after interpolation.
     """
 
     # Check if required keys are in the input_timeseries dictionary
@@ -144,12 +153,12 @@ def assemble_one_year_input(
     linked by timestamp.
 
     Args:
-        soc (pd.DataFrame):      Dataframe with SOC profile and 'Time_s' timestamp
-        climate (pd.DataFrame):  Dataframe with temperature data and 'Time_s' timestamp column
-        time_interval (int):     Interval at which the final data is resampled to
+        - soc (pd.DataFrame):      Dataframe with SOC profile and 'Time_s' timestamp
+        - climate (pd.DataFrame):  Dataframe with temperature data and 'Time_s' timestamp column
+        - time_interval (int):     Interval at which the final data is resampled to
 
     Return:
-        pd.DataFrame:  Combined DataFrame with time, soc, and temperature columns.
+        - pd.DataFrame:  Combined DataFrame with time, soc, and temperature columns.
     """
     # Check if 'Time_s' column exists in both data frames
     if "Time_s" not in soc.columns:
@@ -210,7 +219,16 @@ def tile_to_one_year(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 # TODO (Paul 2/3/2025): something is not exactly perfect but I think it's close enough
-def scale_vehicle_profile_to_annual_efcs(profile, desired_efcs_per_year, show_efcs=False):
+def scale_vehicle_profile_to_annual_efcs(profile:pd.DataFrame, desired_efcs_per_year, show_efcs=False)->pd.DataFrame:
+    """
+    Args:
+        profile (pd.DataFrame):
+        desired_efcs_per_year :
+        show_efcs (bool, optional):
+
+    Returns:
+        pd.DataFrame:
+    """
     profile['dSOC'] = profile['SOC'].diff().fillna(0)
     efcs = 0.5 * profile['dSOC'].abs().sum()
     duration = profile['Time_s'].iloc[-1] - profile['Time_s'].iloc[0]
@@ -272,7 +290,7 @@ def scale_vehicle_profile_to_annual_efcs(profile, desired_efcs_per_year, show_ef
             'SOC': profile.loc[idx_reversals[i] + new_row_count, 'SOC'],
             'dSOC': 0
         })
-        after_rest = profile.iloc[idx_reversals[i] + new_row_count:]
+        after_rest = profile.iloc[idx_reversals[i] + new_row_count:].copy()
         new_time = profile.loc[idx_reversals[i] + new_row_count:, 'Time_s'] + rest_time_per_interval
         # cast new_time to same dtype as 'Time_s' column
         new_time = new_time.astype(profile['Time_s'].dtype)
@@ -293,7 +311,18 @@ def scale_vehicle_profile_to_annual_efcs(profile, desired_efcs_per_year, show_ef
         print(efcs_per_year)
     return profile
 
-def decimate_and_rescale_profile(profile, decimation_factor, tol=1e-1, show_efcs=False):
+def decimate_and_rescale_profile(profile:pd.DataFrame, decimation_factor, tol=1e-1, show_efcs=False)->pd.DataFrame:
+    """
+
+    Args:
+        profile (pd.DataFrame):
+        decimation_factor:
+        tol (float, optional):
+        show_efcs (bool, optional):
+
+    Returns:
+        pd.DataFrame:
+    """
     dSOC = profile['SOC'].diff().fillna(0)
     efcs_original = 0.5 * dSOC.abs().sum()
     if show_efcs:
@@ -312,7 +341,16 @@ def decimate_and_rescale_profile(profile, decimation_factor, tol=1e-1, show_efcs
         print(f"Decimated and rescaled EFCs: {efcs}")
     return profile
 
-def derate_profile(profile, derating_factor, max_soc=0.9):
+def derate_profile(profile:pd.DataFrame, derating_factor, max_soc=0.9)->pd.DataFrame:
+    """
+    Args:
+        profile (pd.DataFrame):
+        derating_factor :
+        max_soc (float, optional):
+
+    Returns:
+        pd.DataFrame:
+    """
     # Derate a profile by scaling dSOC by the derating factor.
     # If feasible, reduce max_soc as well.
     dSOC = profile['SOC'].diff().fillna(0)
@@ -322,15 +360,31 @@ def derate_profile(profile, derating_factor, max_soc=0.9):
         profile['SOC'] = profile['SOC'] - (profile['SOC'].max() - max_soc)
     return profile
 
-def rescale_profile(profile, rescaling_factor):
-    # Rescale a profile by scaling dSOC by the rescaling factor.
+def rescale_profile(profile:pd.DataFrame, rescaling_factor)->pd.DataFrame:
+    """
+    Rescale a profile (pd.Dataframe)by scaling dSOC by the rescaling factor.
+
+    Args:
+        profile (pd.DataFrame):
+        rescaling_factor:
+
+    Returns:
+        pd.DataFrame:
+    """
     dSOC = profile['SOC'].diff().fillna(0)
     dSOC = dSOC * rescaling_factor
     profile['SOC'] = np.cumsum(dSOC) + profile['SOC'].iloc[0]
     return profile
 
-def rescale_soc(soc, rescaling_factor):
-    # Rescale an soc vector by scaling dSOC by the rescaling factor.
+def rescale_soc(soc : np.ndarray, rescaling_factor)->np.ndarray:
+    """
+    Rescale an soc vector by scaling dSOC by the rescaling factor.
+    Args:
+        soc (np.ndarray):
+        rescaling_factor:
+    Returns:
+        np.ndarray:
+    """
     dSOC = np.diff(soc, prepend=soc[0])
     dSOC = dSOC * rescaling_factor
     soc = np.cumsum(dSOC) + soc[0]
@@ -340,10 +394,24 @@ def rescale_soc(soc, rescaling_factor):
     return soc
 
 def simulate_battery_life_distribution(Battery, input, degradation_scalar_std=0.15, degradation_scalar_mean=1., **kwargs):
-    # Simulate the distribution of battery life from normally distributed degradation scalars.
-    # Simulations are done at -3, -2, -1, 0, 1, 2, 3 sigma. The resulting outputs from the 
-    # simulations at any non-zero sigma are resized to be the same size as the nominal simulation
-    # to allow for easy plotting.
+    """
+    Simulate a distribution of battery lifetimes using normally
+    distributed degradation scalars.
+
+    Battery simulations are performed at multiple sigma values
+    (-3, -2, -1, 0, 1, 2, 3) around the mean degradation scalar.
+    Non-nominal simulation outputs are interpolated to match the
+    nominal simulation length for easier comparison and plotting.
+
+    Args:
+        Battery:
+        input:
+        degradation_scalar_std (float, optional):
+        degradation_scalar_mean (float, optional):
+        **kwargs:
+    Returns:
+        dict:
+    """
     sigmas = [0, -3, -2, -1, 1, 2, 3]
     batteries_sigma = {}
     for sigma in sigmas:


### PR DESCRIPTION
This PR improves code readability and maintainability by adding Python type
hints and standardizing docstrings across Python files in the following
modules:

- blast/models
- blast/utils

Changes include:
- Added type hints to function arguments and return values
- Standardized docstrings using Args and Returns sections
- Minor formatting because of adding return type hinds the function definition was becoming to long for a screen

No functional changes were intended.